### PR TITLE
Update to 1.20.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,9 +96,9 @@
                         </goals>
                         <id>remap-obf</id>
                         <configuration>
-                            <srgIn>org.spigotmc:minecraft-server:1.20-R0.1-SNAPSHOT:txt:maps-mojang</srgIn>
+                            <srgIn>org.spigotmc:minecraft-server:1.20.2-R0.1-SNAPSHOT:txt:maps-mojang</srgIn>
                             <reverse>true</reverse>
-                            <remappedDependencies>org.spigotmc:spigot:1.20-R0.1-SNAPSHOT:jar:remapped-mojang</remappedDependencies>
+                            <remappedDependencies>org.spigotmc:spigot:1.20.2-R0.1-SNAPSHOT:jar:remapped-mojang</remappedDependencies>
                             <remappedArtifactAttached>true</remappedArtifactAttached>
                             <remappedClassifierName>remapped-obf</remappedClassifierName>
                         </configuration>
@@ -111,8 +111,8 @@
                         <id>remap-spigot</id>
                         <configuration>
                             <inputFile>${project.build.directory}/${project.artifactId}-${project.version}-remapped-obf.jar</inputFile>
-                            <srgIn>org.spigotmc:minecraft-server:1.20-R0.1-SNAPSHOT:csrg:maps-spigot</srgIn>
-                            <remappedDependencies>org.spigotmc:spigot:1.20-R0.1-SNAPSHOT:jar:remapped-obf</remappedDependencies>
+                            <srgIn>org.spigotmc:minecraft-server:1.20.2-R0.1-SNAPSHOT:csrg:maps-spigot</srgIn>
+                            <remappedDependencies>org.spigotmc:spigot:1.20.2-R0.1-SNAPSHOT:jar:remapped-obf</remappedDependencies>
                         </configuration>
                     </execution>
                 </executions>
@@ -168,7 +168,7 @@
         <dependency>
             <groupId>io.papermc.paper</groupId>
             <artifactId>paper-api</artifactId>
-            <version>1.20.1-R0.1-SNAPSHOT</version>
+            <version>1.20.2-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <!-- Maven Source Plugin -->
@@ -252,7 +252,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot</artifactId>
-            <version>1.20-R0.1-SNAPSHOT</version>
+            <version>1.20.2-R0.1-SNAPSHOT</version>
             <classifier>remapped-mojang</classifier>
             <scope>provided</scope>
         </dependency>

--- a/src/main/java/net/farlands/sanctuary/command/CommandHandler.java
+++ b/src/main/java/net/farlands/sanctuary/command/CommandHandler.java
@@ -5,6 +5,7 @@ import com.kicas.rp.RegionProtection;
 import com.kicas.rp.data.FlagContainer;
 import com.kicas.rp.data.RegionFlag;
 import com.kicas.rp.data.flagdata.StringFilter;
+import com.kicas.rp.util.ReflectionHelper;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
 import net.dv8tion.jda.api.interactions.commands.SlashCommandInteraction;
@@ -28,8 +29,6 @@ import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.Bukkit;
 import org.bukkit.command.BlockCommandSender;
 import org.bukkit.command.CommandSender;
-import org.bukkit.craftbukkit.v1_20_R1.CraftServer;
-import org.bukkit.craftbukkit.v1_20_R1.command.VanillaCommandWrapper;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -252,7 +251,8 @@ public class CommandHandler extends Mechanic {
             FarLands.getDiscordHandler().registerAutocompleters(ac);
         }
         commands.add(command);
-        ((CraftServer) Bukkit.getServer()).getCommandMap().register("farlands", command);
+
+        Bukkit.getServer().getCommandMap().register("farlands", command);
     }
 
     private void registerCommand(SlashCommand command) {
@@ -334,13 +334,18 @@ public class CommandHandler extends Mechanic {
             org.bukkit.command.Command bukkitCommand = Bukkit.getServer().getCommandMap().getCommand(commandName);
 
             // See if it's a vanilla command
-            if (bukkitCommand instanceof VanillaCommandWrapper cmd) {
+            Class<?> vanillaCommandWrapperClass = FLUtils.getCraftBukkitClass("command.VanillaCommandWrapper");
+            // if (bukkitCommand instanceof VanillaCommandWrapper cmd) {
+            if (vanillaCommandWrapperClass.isInstance(bukkitCommand)) {
                 // Ensure the sender has permission
-                if (!cmd.testPermission(sender)) {
+
+                // if (!cmd.testPermission(sender)) {
+                if (!(Boolean) ReflectionHelper.invoke("testPermission", vanillaCommandWrapperClass, bukkitCommand, sender)) {
                     return false;
                 }
 
-                cmd.execute(sender, commandName, args);
+                // cmd.execute(sender, commandName, args);
+                ReflectionHelper.invoke("execute", vanillaCommandWrapperClass, bukkitCommand, sender, commandName, args);
 
                 return true;
             }

--- a/src/main/java/net/farlands/sanctuary/command/CommandHandler.java
+++ b/src/main/java/net/farlands/sanctuary/command/CommandHandler.java
@@ -125,6 +125,7 @@ public class CommandHandler extends Mechanic {
         registerCommand(new CommandPTime());            // Knight
         registerCommand(new CommandPvP());              // Initiate
         registerCommand(new CommandPWeather());         // Sage
+        registerCommand(new CommandRandom());           // Initiate
         registerCommand(new CommandRanks());            // Initiate
         registerCommand(new CommandRankup());           // Initiate
         registerCommand(new CommandRealName());         // Initiate

--- a/src/main/java/net/farlands/sanctuary/command/player/CommandRandom.java
+++ b/src/main/java/net/farlands/sanctuary/command/player/CommandRandom.java
@@ -1,0 +1,108 @@
+package net.farlands.sanctuary.command.player;
+
+import com.kicas.rp.command.TabCompleterBase;
+import com.kicasmads.cs.Utils;
+import net.farlands.sanctuary.FarLands;
+import net.farlands.sanctuary.command.Category;
+import net.farlands.sanctuary.command.Command;
+import net.farlands.sanctuary.command.CommandData;
+import net.farlands.sanctuary.data.struct.OfflineFLPlayer;
+import net.farlands.sanctuary.util.FLUtils;
+import net.farlands.sanctuary.util.Logging;
+import net.farlands.sanctuary.util.Range;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.TranslatableComponent;
+import org.bukkit.Location;
+import org.bukkit.command.CommandSender;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+public class CommandRandom extends Command {
+
+    public CommandRandom() {
+        super(
+            CommandData.simple(
+                    "random",
+                    "Generate a random number and broadcast it to other players on the server",
+                    "/random <roll|value> <range>"
+                )
+                .category(Category.CHAT)
+        );
+    }
+
+    @Override
+    public boolean execute(CommandSender sender, String[] args) {
+        if (args.length != 2) {
+            return false;
+        }
+
+        SubCommand subcommand = Utils.valueOfFormattedName(args[0], SubCommand.class);
+        if (subcommand == null) {
+            return false;
+        }
+        Range<Integer> range;
+        try {
+            range = Range.from(args[1]);
+        } catch (IllegalArgumentException ex) {
+            error(sender, ex.getMessage());
+            return false;
+        }
+
+        OfflineFLPlayer flp = FarLands.getDataHandler().getOfflineFLPlayer(sender);
+
+        int low = range.low() == null ? 0 : range.low();
+        int high = range.high() == null ? Integer.MAX_VALUE : range.high();
+
+        if (high < low) {
+            return error(sender, "Invalid Range: high must be greater than low.");
+        }
+
+        int result = FLUtils.randomInt(low, high);
+
+        switch(subcommand) {
+            case ROLL -> {
+                TranslatableComponent comp = Component.translatable("commands.random.roll")
+                    .args(
+                        flp,
+                        Component.text(result),
+                        Component.text(low),
+                        Component.text(high)
+                    );
+                Logging.broadcastIngame(session -> !session.handle.getIgnoreStatus(sender).includesChat(), comp, true);
+            }
+            case VALUE -> {
+                TranslatableComponent comp = Component.translatable("commands.random.sample.success").args(Component.text(result));
+                sender.sendMessage(comp);
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public List<String> tabComplete(CommandSender sender, String alias, String[] args, Location location) throws IllegalArgumentException {
+        return switch (args.length) {
+            case 1 -> TabCompleterBase.filterStartingWith(args[0], SubCommand.FORMATTED);
+            case 2 -> {
+                String arg = args[1];
+                if (arg.length() == 0 || arg.contains("..")) {
+                    yield List.of(arg);
+                }
+                if (arg.endsWith(".")) {
+                    yield List.of(arg + ".");
+                }
+                yield List.of(arg + "..");
+            }
+            default -> Collections.emptyList();
+        };
+    }
+
+    public enum SubCommand {
+        ROLL,
+        VALUE,
+        ;
+
+        public static List<String> FORMATTED = Arrays.stream(SubCommand.values()).map(Utils::formattedName).toList();
+    }
+}

--- a/src/main/java/net/farlands/sanctuary/command/player/CommandStack.java
+++ b/src/main/java/net/farlands/sanctuary/command/player/CommandStack.java
@@ -8,16 +8,19 @@ import com.kicas.rp.data.flagdata.TrustLevel;
 import com.kicas.rp.data.flagdata.TrustMeta;
 import com.kicas.rp.util.Materials;
 import com.kicas.rp.util.Pair;
+import com.kicas.rp.util.ReflectionHelper;
 import net.farlands.sanctuary.command.PlayerCommand;
 import net.farlands.sanctuary.data.Rank;
 import net.farlands.sanctuary.util.ComponentColor;
 import net.farlands.sanctuary.util.ComponentUtils;
+import net.farlands.sanctuary.util.FLUtils;
 import net.farlands.sanctuary.util.LocationWrapper;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.JoinConfiguration;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.Style;
 import net.kyori.adventure.text.format.TextDecoration;
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -26,7 +29,6 @@ import org.bukkit.block.BlockFace;
 import org.bukkit.block.ShulkerBox;
 import org.bukkit.block.data.type.WallSign;
 import org.bukkit.command.CommandSender;
-import org.bukkit.craftbukkit.v1_20_R1.CraftWorld;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.BlockStateMeta;
@@ -115,7 +117,9 @@ public class CommandStack extends PlayerCommand {
                 }
 
                 BlockEntity tileEntity;
-                if (block == null || (tileEntity = ((CraftWorld) player.getWorld()).getHandle()
+                // tileEntity = ((CraftWorld) player.getWorld()).getHandle().getBlockEntity().getBlockEntity(...)
+                if (block == null || (tileEntity =
+                    ((ServerLevel) ReflectionHelper.invoke("getHandle", FLUtils.getCraftBukkitClass("CraftWorld"), player.getWorld()))
                         .getBlockEntity(new LocationWrapper(block.getLocation()).asBlockPos(), true)) == null ||
                     !ACCEPTED_CONTAINERS.contains(block.getType())) {
                     player.sendMessage(ComponentColor.red("Target block must be a chest or barrel"));

--- a/src/main/java/net/farlands/sanctuary/gui/GuiVillagerEditor.java
+++ b/src/main/java/net/farlands/sanctuary/gui/GuiVillagerEditor.java
@@ -4,7 +4,6 @@ import net.farlands.sanctuary.FarLands;
 import net.farlands.sanctuary.util.ComponentColor;
 import net.kyori.adventure.text.Component;
 import org.bukkit.Material;
-import org.bukkit.craftbukkit.v1_20_R1.entity.CraftVillager;
 import org.bukkit.entity.Villager;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.inventory.ItemStack;
@@ -54,7 +53,7 @@ public class GuiVillagerEditor extends Gui {
      *
      * @param villager Villager to edit
      */
-    public GuiVillagerEditor(CraftVillager villager) {
+    public GuiVillagerEditor(Villager villager) {
         super(Component.text(SCREEN_NAMES[0]), 54);
         this.villager = villager;
         this.screens = new ArrayList<>();

--- a/src/main/java/net/farlands/sanctuary/mechanic/GeneralMechanics.java
+++ b/src/main/java/net/farlands/sanctuary/mechanic/GeneralMechanics.java
@@ -33,7 +33,6 @@ import net.kyori.adventure.text.format.TextDecoration;
 import org.bukkit.*;
 import org.bukkit.block.*;
 import org.bukkit.block.data.Rail;
-import org.bukkit.craftbukkit.v1_20_R1.entity.CraftVillager;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.*;
 import org.bukkit.event.EventHandler;
@@ -526,7 +525,7 @@ public class GeneralMechanics extends Mechanic {
             Material.BLAZE_ROD == hand.getType() && Rank.getRank(event.getPlayer()).isStaff()) {
             event.setCancelled(true);
             FarLands.getDataHandler().getPluginData().addSpawnTrader(ent.getUniqueId());
-            (new GuiVillagerEditor((CraftVillager) ent)).openGui(event.getPlayer());
+            new GuiVillagerEditor((Villager) ent).openGui(event.getPlayer());
         } else if (LEASHABLE_ENTITIES.contains(event.getRightClicked().getType()) && !FLUtils.isInSpawn(event.getRightClicked().getLocation()) &&
                    event.getRightClicked() instanceof LivingEntity) {
             final LivingEntity entity = (LivingEntity) ent;

--- a/src/main/java/net/farlands/sanctuary/mechanic/TabListMechanics.java
+++ b/src/main/java/net/farlands/sanctuary/mechanic/TabListMechanics.java
@@ -3,6 +3,7 @@ package net.farlands.sanctuary.mechanic;
 import com.destroystokyo.paper.event.server.PaperServerListPingEvent;
 import com.google.common.collect.ImmutableMap;
 import com.kicas.rp.util.Pair;
+import com.kicas.rp.util.ReflectionHelper;
 import net.farlands.sanctuary.FarLands;
 import net.farlands.sanctuary.data.DataHandler;
 import net.farlands.sanctuary.data.FLPlayerSession;
@@ -14,10 +15,10 @@ import net.farlands.sanctuary.util.FLUtils;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.JoinConfiguration;
 import net.kyori.adventure.text.format.TextColor;
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.MobCategory;
 import org.bukkit.Bukkit;
 import org.bukkit.World;
-import org.bukkit.craftbukkit.v1_20_R1.CraftWorld;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.SpawnCategory;
 import org.bukkit.event.EventHandler;
@@ -176,7 +177,8 @@ public class TabListMechanics extends Mechanic {
         .build();
 
     private static Component getMobCap(World world, SpawnCategory cat) {
-        var level = ((CraftWorld) world).getHandle();
+        Class<?> craftworldclass = FLUtils.getCraftBukkitClass("CraftWorld");
+        var level = (ServerLevel) ReflectionHelper.invoke("getHandle", craftworldclass, world);
         var lim = world.getSpawnLimit(cat);
         var s = level.getChunkSource().getLastSpawnState();
         var c = s.getMobCategoryCounts().getOrDefault(categoryConversions.get(cat), -1);

--- a/src/main/java/net/farlands/sanctuary/mechanic/Toggles.java
+++ b/src/main/java/net/farlands/sanctuary/mechanic/Toggles.java
@@ -6,16 +6,18 @@ import com.comphenix.protocol.ProtocolManager;
 import com.comphenix.protocol.events.PacketAdapter;
 import com.comphenix.protocol.events.PacketContainer;
 import com.comphenix.protocol.events.PacketEvent;
+import com.kicas.rp.util.ReflectionHelper;
 import net.farlands.sanctuary.FarLands;
 import net.farlands.sanctuary.data.FLPlayerSession;
 import net.farlands.sanctuary.data.Rank;
 import net.farlands.sanctuary.data.struct.OfflineFLPlayer;
 import net.farlands.sanctuary.util.ComponentColor;
+import net.farlands.sanctuary.util.FLUtils;
 import net.minecraft.network.protocol.game.ClientboundPlayerInfoUpdatePacket;
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.level.GameType;
 import org.bukkit.Bukkit;
 import org.bukkit.GameMode;
-import org.bukkit.craftbukkit.v1_20_R1.entity.CraftPlayer;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.Projectile;
@@ -183,7 +185,9 @@ public class Toggles extends Mechanic {
     private static void showSpectators(Player player) {
         ProtocolManager pm = ProtocolLibrary.getProtocolManager();
         ClientboundPlayerInfoUpdatePacket packet = new ClientboundPlayerInfoUpdatePacket(
-            ClientboundPlayerInfoUpdatePacket.Action.UPDATE_GAME_MODE, ((CraftPlayer) player).getHandle()
+            ClientboundPlayerInfoUpdatePacket.Action.UPDATE_GAME_MODE,
+            // ((CraftPlayer) player).getHandle()
+            (ServerPlayer) ReflectionHelper.invoke("getHandle", FLUtils.getCraftBukkitClass("entity.CraftPlayer"), player)
         );
 
         Bukkit.getScheduler().runTask(FarLands.getInstance(), () -> {

--- a/src/main/java/net/farlands/sanctuary/mechanic/region/AutumnEvent.java
+++ b/src/main/java/net/farlands/sanctuary/mechanic/region/AutumnEvent.java
@@ -3,6 +3,7 @@ package net.farlands.sanctuary.mechanic.region;
 import com.kicas.rp.data.Region;
 import com.kicas.rp.util.Entities;
 import com.kicas.rp.util.Pair;
+import com.kicas.rp.util.ReflectionHelper;
 import net.farlands.sanctuary.FarLands;
 import net.farlands.sanctuary.command.FLShutdownEvent;
 import net.farlands.sanctuary.data.Cooldown;
@@ -20,7 +21,6 @@ import net.minecraft.world.item.Items;
 import org.bukkit.*;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.block.BlockFace;
-import org.bukkit.craftbukkit.v1_20_R1.inventory.CraftItemStack;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.*;
 import org.bukkit.event.EventHandler;
@@ -3057,7 +3057,9 @@ public class AutumnEvent extends Mechanic {
         // TODO: 7/3/21 This player head item needs to be tested. It may not be the right item
         net.minecraft.world.item.ItemStack dropCB = new net.minecraft.world.item.ItemStack(Items.PLAYER_HEAD, 1);
         dropCB.setTag(tag); // ItemStack#setTag
-        return CraftItemStack.asBukkitCopy(dropCB);
+
+        // CraftItemStack.asBukkitCopy(dropCB);
+        return (ItemStack) ReflectionHelper.invoke("asBukkitCopy", FLUtils.getCraftBukkitClass("inventory.CraftItemStack"), null, dropCB);
     }
 }
 

--- a/src/main/java/net/farlands/sanctuary/util/FireworkBuilder.java
+++ b/src/main/java/net/farlands/sanctuary/util/FireworkBuilder.java
@@ -1,12 +1,11 @@
 package net.farlands.sanctuary.util;
 
+import com.kicas.rp.util.ReflectionHelper;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
 import net.minecraft.world.entity.projectile.FireworkRocketEntity;
 import org.bukkit.Location;
 import org.bukkit.Material;
-import org.bukkit.craftbukkit.v1_20_R1.entity.CraftFirework;
-import org.bukkit.craftbukkit.v1_20_R1.inventory.CraftItemStack;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Firework;
 import org.bukkit.inventory.ItemStack;
@@ -114,18 +113,24 @@ public class FireworkBuilder {
 
     public void spawnEntity(Location loc) {
         Firework firework = (Firework) loc.getWorld().spawnEntity(loc, EntityType.FIREWORK);
-        FireworkRocketEntity entity = ((CraftFirework) firework).getHandle();
+
+        FireworkRocketEntity entity = (FireworkRocketEntity) ReflectionHelper.invoke("getHandle", FLUtils.getCraftBukkitClass("entity.CraftFirework"), firework);
         entity.addAdditionalSaveData(toNBT());
     }
 
     public ItemStack buildItemStack(int stackSize) {
-        net.minecraft.world.item.ItemStack stack = CraftItemStack.asNMSCopy(new ItemStack(Material.FIREWORK_ROCKET, stackSize));
+        Class<?> craftitemstackclass = FLUtils.getCraftBukkitClass("inventory.CraftItemStack");
+        // net.minecraft.world.item.ItemStack stack = CraftItemStack.asNMSCopy(new ItemStack(Material.FIREWORK_ROCKET, stackSize));
+        net.minecraft.world.item.ItemStack stack = (net.minecraft.world.item.ItemStack)
+            ReflectionHelper.invoke("asNMSCopy", craftitemstackclass, null, new ItemStack(Material.FIREWORK_ROCKET, stackSize));
         CompoundTag stackTag = toNBT().getCompound("FireworksItem").getCompound("tag"); // getCompound
         int flightRaw = (int) Math.ceil(((double) lifetime) / 20.0);
         int flight = flightRaw < 1 ? 1 : Math.min(flightRaw, 3);
         stackTag.getCompound("Fireworks").putByte("Flight", (byte) (flight & 0xFF)); // getCompound, setCompound
         stack.setTag(stackTag); // setTag
-        return CraftItemStack.asBukkitCopy(stack);
+
+        // return CraftItemStack.asBukkitCopy(stack);
+        return (ItemStack) ReflectionHelper.invoke("asBukkitCopy", craftitemstackclass, null, stack);
     }
 
     private static class Explosion {

--- a/src/main/java/net/farlands/sanctuary/util/Range.java
+++ b/src/main/java/net/farlands/sanctuary/util/Range.java
@@ -66,6 +66,34 @@ public class Range<T extends Comparable<T>> {
     }
 
     /**
+     * @return the lower bound of this range
+     */
+    public T low() {
+        return this.low;
+    }
+
+    /**
+     * @return the higher bound of this range
+     */
+    public T high() {
+        return this.high;
+    }
+
+    /**
+     * @return if this range includes the lower bound
+     */
+    public boolean includeLow() {
+        return this.inclLow;
+    }
+
+    /**
+     * @return if this range includes the higher bound
+     */
+    public boolean includeHigh() {
+        return this.inclHigh;
+    }
+
+    /**
      * Parse a "Rust-style" range string into a {@link Range<Integer>}, like the following:
      * <ul>
      *     <li>{@code a..b}</li>


### PR DESCRIPTION
In the past, we've been able to just do the mechanical change of
`s/1_20_R1/1_20_R2`, but paper has made changes where we can't directly
access CraftBukkit.

This pr updates the pom.xml and changes all instances of craftbukkit api usage to instead
use reflection, [as paper says](https://forums.papermc.io/threads/paper-velocity-1-20-2.920).

There are two main side effects of this:
- The code is a bit harder to read, though only in a few places
- We should no longer need to update anything in the plugin when we want
  to update the server.